### PR TITLE
Filtering out inactive pokemon from the pokemon index and map

### DIFF
--- a/app/controllers/pokemons_controller.rb
+++ b/app/controllers/pokemons_controller.rb
@@ -6,12 +6,9 @@ class PokemonsController < ApplicationController
   before_action :set_pokemon, only: [:show, :update, :edit, :deactivate, :reactivate]
 
   def index
-    # raise
     @pokemons = policy_scope(Pokemon)
 
-    @pokemon_location = Pokemon.where.not(latitude: nil, longitude: nil)
-
-    @markers = @pokemon_location.map do |selected|
+    @markers = @pokemons.map do |selected|
       {
         lat: selected.latitude,
         lng: selected.longitude,

--- a/app/models/pokemon.rb
+++ b/app/models/pokemon.rb
@@ -5,7 +5,7 @@ class Pokemon < ApplicationRecord
   belongs_to :user
   has_many :bookings
 
-  validates :name, :level, :category, :price_per_day, presence: true
+  validates :name, :level, :category, :address, :price_per_day, presence: true
   validates :price_per_day, :rating, numericality: true
 
   # TODO: Validate photos and ratings?

--- a/app/policies/pokemon_policy.rb
+++ b/app/policies/pokemon_policy.rb
@@ -1,7 +1,7 @@
 class PokemonPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.where.not(user: user)
+      scope.where.not("user_id = :user or is_active = :is_active or latitude is null or longitude is null", user: user, is_active: false)
     end
   end
 


### PR DESCRIPTION
#53 

Making address a required field for new pokemon

Pokemon that are inactive AND don't have latitude/longitude set will not appear on both the map and index list