### PR TITLE
rewrote the date validation

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -12,7 +12,6 @@ class BookingsController < ApplicationController
   end
 
   def update
-
   end
 
   def new
@@ -29,6 +28,7 @@ class BookingsController < ApplicationController
     @booking.pokemon_id = params[:pokemon_id]
     @booking.user_id = current_user[:id]
     @booking.price_paid = ((@booking.end_dt - @booking.start_dt) * @pokemon.price_per_day)
+    @booking.range = (@booking.start_dt..@booking.end_dt)
     if @booking.save
       redirect_to bookings_path
     else

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -4,7 +4,8 @@ class Booking < ApplicationRecord
   belongs_to :pokemon
   has_one :review
 
-  validates :start_dt, :end_dt, presence: true, availability: true
+  validates :start_dt, :end_dt, presence: true
+  validates :range, presence: true, availability: true
   validate :end_date_after_start_date
 
   private

--- a/app/validators/availability_validator.rb
+++ b/app/validators/availability_validator.rb
@@ -5,7 +5,7 @@ class AvailabilityValidator < ActiveModel::EachValidator
     date_ranges = bookings.map { |b| b.start_dt..b.end_dt }
 
     date_ranges.each do |range|
-      if range.include? value
+      if range.overlaps? value
         record.errors.add(attribute, "not available")
       end
     end

--- a/db/migrate/20190602133817_add_column_range_to_bookings.rb
+++ b/db/migrate/20190602133817_add_column_range_to_bookings.rb
@@ -1,0 +1,5 @@
+class AddColumnRangeToBookings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookings, :range, :daterange
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_30_035845) do
+ActiveRecord::Schema.define(version: 2019_06_02_133817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2019_05_30_035845) do
     t.bigint "pokemon_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.daterange "range"
     t.index ["pokemon_id"], name: "index_bookings_on_pokemon_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end


### PR DESCRIPTION
figured out the issue:

original validator was only checking start date and end data against the unavailable dates array, but did not check the dates in between those.  Therefore it would always allow the booking as long as the start date and end dates were valid irrespective of dates unavailable within the range.

- I added a daterange column type called 'range' = (start_dt..end_dt) which saves as a range type. 
- This allows a single value to then be passed through the custom validator as required.
- This is compared against the array of unavailable ranges using 'range.overlaps? value' to check for overlapping ranges of the range entered via the date picker.
- A rails db:migrate and rails db:reseed is required after this update